### PR TITLE
add config useInvoiceAmountAsPaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Payment Method Feature:
 #### Installation
 
 1. [Download](../../archive/master.zip) the modules from this repository.
-2. Extract `Whmcs-master.zip` file you have previously downloaded.
+2. Extract `snap-whmcs-master.zip` file you have previously downloaded.
 3. Upload & merge `modules` folder that you have extracted into your WHMCS directory `modules` folder. 
 
 #### Installation & Configuration
@@ -46,6 +46,10 @@ Payment Method Feature:
 If you encounter payment popup not being properly opened on invoice page, try these solution:
 
 On menu `Setup -> Payments -> Payment Gateways`, tick option `Payment Redirect To Midtrans`. Customer will be redirected to Midtrans instead of popup. This can minimize popup issue.
+
+If you use non IDR currency on WHMCS and encounter issue of paid amount is too big or does not match with invoice amount: 
+
+Try to enable configuration `Use Invoice amount as paid amount` to use the invoice amount as paid amount. Note: this will also means it will not check the actual paid amount on Payment Gateway, but it can avoid currency conversion issues.
 
 #### Get help
 

--- a/modules/gateways/callback/veritrans.php
+++ b/modules/gateways/callback/veritrans.php
@@ -65,6 +65,17 @@ $paymentFee = 0;
 $invoiceId = checkCbInvoiceID($invoiceId, $gatewayParams['name']);
 
 /**
+ * If useInvoiceAmountAsPaid enabled, use the invoice amount, as paid amount
+ * this to avoid currency conversion issue on non IDR WHMCS transaction
+ */
+
+if ($gatewayParams['useInvoiceAmountAsPaid'] == 'on') {
+  $invoice_result = mysql_fetch_assoc(select_query('tblinvoices', 'total, userid', array("id"=>$order_id)));
+  $invoice_amount = $invoice_result['total'];
+  $paymentAmount = $invoice_amount;
+}
+
+/**
  * Log Transaction.
  *
  * Add an entry to the Gateway Log for debugging purposes.

--- a/modules/gateways/veritrans.php
+++ b/modules/gateways/veritrans.php
@@ -166,6 +166,11 @@ function veritrans_config()
             'Type' => 'yesno',
             'Description' => 'Tick to make payment page redirect to Midtrans, instead of popup (recommended to set it: off)',
         ),
+        'useInvoiceAmountAsPaid' => array(
+            'FriendlyName' => 'Use Invoice amount as paid amount',
+            'Type' => 'yesno',
+            'Description' => 'Only use this if you use other than IDR currency, and encounter amount mismatch issue on paid invoice (recommended to set it: off)',
+        ),
     );
 }
 
@@ -200,6 +205,7 @@ function veritrans_link($params)
     $enabledPayments = $params['enabledPayments'];
     $minimumInstallmentAmount = $params['minimumInstallmentAmount'];
     $enableSnapRedirect = $params['enableSnapRedirect'];
+    $useInvoiceAmountAsPaid = $params['useInvoiceAmountAsPaid'];
 
     // Invoice Parameters
     $invoiceId = $params['invoiceid'];


### PR DESCRIPTION
work around for issue https://github.com/veritrans/SNAP-whmcs/issues/8

If you use non IDR currency on WHMCS and encounter issue of paid amount is too big or does not match with invoice amount: 

Try to enable configuration `Use Invoice amount as paid amount` to use the invoice amount as paid amount. Note: this will also means it will not check the actual paid amount on Payment Gateway, but it can avoid currency conversion issues.

TODO: Proper fix may still need to be implemented, which should use proper conversion of PG paid amount to original currency